### PR TITLE
Copy IPFS submission template

### DIFF
--- a/sessions/README.md
+++ b/sessions/README.md
@@ -1,0 +1,25 @@
+# Proposing Sessions
+
+To propose a session, follow these instructions.
+
+## Step 1: Create a file using the template
+
+In a branch or fork of this repository (or through github's web interface):
+
+1. Create a new file in [/sessions](./) folder of this repository.
+2. Paste the contents of [_template.md](./_template.md) into the file
+
+## Step 2: Write your Session Proposal
+
+Fill in the fields in the template. You can use [this example proposal](./_example.md) as a reference.
+
+- **Title:**  On the first line, provide a title for your session using the format `# Session: Your-Session-Title`
+- **Description and Motivation:** Describe the session and the motivation for having a session on that topic.
+- **Activity:** Describe the activity/format of the session.
+- **Goal(s):** List the goals/objectives of the session.
+- **Duration:** Specify whether the session will be 30 mins or 60 minutes
+- **Participation:** Declare who should participate in this session, especially anyone who MUST be in that session in order for it to be successful.
+- **Agenda:** Outline the agenda for your session, spelling out how you will use the time.
+
+## Step 3: Submit the pull request
+When your proposal is ready to submit, create a new PR on this repository. Put your session title in the title of the PR.

--- a/sessions/_example.md
+++ b/sessions/_example.md
@@ -1,0 +1,19 @@
+# (example) Session: NPM on IPFS
+
+**Description:** npm on IPFS has been one of the highest seller points within the JS community. We had a great start, but, unfortunately, this endeavour got stale due to the lack of sharding. Let's deliver this ASAP (make npm work offline o/)
+
+**Activity:** Discussion, enumerate tasks to be perform
+
+**Goal(s):**
+- Establish a new solid roadmap for supporting NPM on IPFS
+
+**Duration:** 30 mins
+
+**Participation:** JavaScript Developers and @whyrusleeping for sharding
+
+---
+# Agenda
+- Review previous Roadmap
+- Review state of sharding
+- Review what kind of infra we need to have this working
+- Update the roadmap

--- a/sessions/_template.md
+++ b/sessions/_template.md
@@ -1,0 +1,19 @@
+# (example) Session: NPM on IPFS
+
+**Description:** _{enter your description here}_
+
+**Activity:** _{describe the activity/format of this session}_
+
+**Goal(s):**
+_{list the goals/objectives of the session.}_
+
+At the end of this session the participants will have:
+- GOAL
+
+**Duration:** _{Specify: 30 mins or 60 minutes}_
+
+**Participation:** _{who should participate in this session}_
+
+---
+# Agenda
+_{outline the agenda for your session}_


### PR DESCRIPTION
This PR brings [IPFS's sessions submission template](https://github.com/ipfs/developer-meetings/tree/proposing-sessions) over here to `libp2p/developer-meetings`.  I'll keep rebasing it as IPFS's changes.